### PR TITLE
Styling refactors + hierarchical team categorisation

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -10,6 +10,7 @@
 html,
 body {
   @apply bg-white dark:bg-gray-950;
+  scrollbar-gutter: stable;
 
   @media (prefers-color-scheme: dark) {
     color-scheme: dark;

--- a/app/bet-log/bet-history.tsx
+++ b/app/bet-log/bet-history.tsx
@@ -15,6 +15,7 @@ type BetHistoryProps = {
   handleBetDeletion: (betId: string) => void;
   isShowBetSettlementSpinner: boolean;
   currentBetIdBeingSettled: string;
+  onDeleteDrawerOpenChange?: (isOpen: boolean) => void;
 };
 
 export default function BetHistory({
@@ -23,14 +24,26 @@ export default function BetHistory({
   handleBetDeletion,
   isShowBetSettlementSpinner,
   currentBetIdBeingSettled,
+  onDeleteDrawerOpenChange,
 }: BetHistoryProps) {
   const [deletingBetId, setDeletingBetId] = useState<string | null>(null);
+
+  const openDeleteDrawer = (betId: string) => {
+    setDeletingBetId(betId);
+    onDeleteDrawerOpenChange?.(true);
+  };
+
+  const closeDeleteDrawer = () => {
+    setDeletingBetId(null);
+    onDeleteDrawerOpenChange?.(false);
+  };
 
   return (
     <>
       <BottomDrawer
         isOpen={deletingBetId !== null}
-        onClose={() => setDeletingBetId(null)}
+        onClose={closeDeleteDrawer}
+        direction="top"
       >
         <div className="space-y-4 text-purple-200">
           <div className="text-xl font-bold text-center">Delete Bet?</div>
@@ -38,7 +51,7 @@ export default function BetHistory({
             label="slide to delete"
             onConfirm={() => {
               handleBetDeletion(deletingBetId!);
-              setDeletingBetId(null);
+              closeDeleteDrawer();
             }}
           />
         </div>
@@ -154,7 +167,7 @@ export default function BetHistory({
                   height="24"
                   fill="none"
                   viewBox="0 0 24 24"
-                  onClick={() => setDeletingBetId(bet.id)}
+                  onClick={() => openDeleteDrawer(bet.id)}
                 >
                   <path
                     stroke="currentColor"

--- a/app/bet-log/bet-log.tsx
+++ b/app/bet-log/bet-log.tsx
@@ -238,6 +238,9 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
     useState<boolean>(false);
   const [isTeamPickerOpen, setIsTeamPickerOpen] = useState<boolean>(false);
   const [isLinePickerOpen, setIsLinePickerOpen] = useState<boolean>(false);
+  const [isDeleteDrawerOpen, setIsDeleteDrawerOpen] = useState<boolean>(false);
+  const [isBalancesDrawerOpen, setIsBalancesDrawerOpen] =
+    useState<boolean>(false);
   const [addEntryCollection, setAddEntryCollection] =
     useState<CollectionName | null>(null);
   const [newOptionName, setNewOptionName] = useState<string>("");
@@ -295,18 +298,28 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
         : "bg-gray-400 dark:bg-purple-700/50"
     }`;
 
+  const allDrawersClosed =
+    !isAddEntryDrawerOpen &&
+    !isTeamPickerOpen &&
+    !isLinePickerOpen &&
+    !isDeleteDrawerOpen &&
+    !isBalancesDrawerOpen;
+
+  const fabClass =
+    "w-14 h-14 rounded-full bg-gray-900 border-1 border-purple-800 text-purple-200 text-3xl font-bold shadow-lg hover:bg-gray-800 hover:border-2 cursor-pointer focus:outline-none flex items-center justify-center";
+
   return (
     <main className="flex-col p-8 space-y-4">
       {/* Floating bottom-right button group */}
       <div className="fixed bottom-4 right-4 flex items-end gap-2 z-50">
         {/* + FAB */}
-        {!isAddEntryDrawerOpen && !isTeamPickerOpen && !isLinePickerOpen && (
+        {allDrawersClosed && (
           <button
             onClick={() => {
               resetAddEntryForm();
               setIsAddEntryDrawerOpen(true);
             }}
-            className="w-14 h-14 rounded-full bg-gray-900 border-1 border-purple-800 text-purple-200 text-3xl font-bold shadow-lg hover:bg-gray-800 hover:border-2 cursor-pointer focus:outline-none flex items-center justify-center"
+            className={fabClass}
             aria-label="Add new entry"
           >
             +
@@ -314,16 +327,19 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
         )}
 
         {/* Show Balances */}
-        {!isAddEntryDrawerOpen && !isTeamPickerOpen && !isLinePickerOpen && (
-          <Drawer
-            trigger={
-              <div className="w-full h-full rounded-full bg-gray-900 border-1 border-purple-800 text-purple-200 text-3xl font-bold hover:bg-gray-800 hover:border-2 flex items-center justify-center">
-                $
-              </div>
-            }
-            triggerSize="w-14 h-14"
+        {allDrawersClosed && (
+          <button
+            onClick={() => setIsBalancesDrawerOpen(true)}
+            className={fabClass}
+            aria-label="Show balances"
+          >
+            $
+          </button>
+        )}
+        <Drawer
+            isOpen={isBalancesDrawerOpen}
+            onClose={() => setIsBalancesDrawerOpen(false)}
             width="w-80"
-            inline
           >
             <div className="flex-col space-y-4">
               {users.map((u) => {
@@ -351,7 +367,6 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
               })}
             </div>
           </Drawer>
-        )}
       </div>
 
       {/* Add Entry Bottom Drawer */}
@@ -560,6 +575,7 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
           handleBetDeletion={handleBetDeletion}
           isShowBetSettlementSpinner={isShowBetSettlementSpinner}
           currentBetIdBeingSettled={currentBetIdBeingSettled}
+          onDeleteDrawerOpenChange={setIsDeleteDrawerOpen}
         />
       </div>
     </main>

--- a/app/bet-log/bet-log.tsx
+++ b/app/bet-log/bet-log.tsx
@@ -245,11 +245,23 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
     useState<CollectionName | null>(null);
   const [newOptionName, setNewOptionName] = useState<string>("");
   const [newLineType, setNewLineType] = useState<LineType>(LineType.NONE);
+  const [newTeamSport, setNewTeamSport] = useState<string>("");
+  const [newTeamLeague, setNewTeamLeague] = useState<string>("");
+  const [newTeamCategory, setNewTeamCategory] = useState<string>("");
+  const [isNewSport, setIsNewSport] = useState<boolean>(false);
+  const [isNewLeague, setIsNewLeague] = useState<boolean>(false);
+  const [isNewCategory, setIsNewCategory] = useState<boolean>(false);
 
   const resetAddEntryForm = () => {
     setAddEntryCollection(null);
     setNewOptionName("");
     setNewLineType(LineType.NONE);
+    setNewTeamSport("");
+    setNewTeamLeague("");
+    setNewTeamCategory("");
+    setIsNewSport(false);
+    setIsNewLeague(false);
+    setIsNewCategory(false);
   };
 
   const handleAddNewOption = async () => {
@@ -269,6 +281,11 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
       const newOption = {
         name: newOptionName,
         ...(collectionName === "lines" && { lineType: newLineType }),
+        ...(collectionName === FIRESTORE_COLLECTION.Teams && {
+          ...(newTeamSport && { sport: newTeamSport }),
+          ...(newTeamLeague && { league: newTeamLeague }),
+          ...(newTeamCategory && { category: newTeamCategory }),
+        }),
       };
 
       const docRef = await addDoc(collection(db, collectionName), newOption);
@@ -297,6 +314,38 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
         ? "bg-purple-300 dark:bg-purple-500/75"
         : "bg-gray-400 dark:bg-purple-700/50"
     }`;
+
+  // Derived sport/league/category option lists for the add-team form
+  const existingSports = [
+    ...new Set(
+      teams.map((t) => t.sport).filter((s): s is string => Boolean(s)),
+    ),
+  ].sort();
+  const existingLeagues = [
+    ...new Set(
+      teams
+        .filter((t) => t.sport === newTeamSport)
+        .map((t) => t.league)
+        .filter((l): l is string => Boolean(l)),
+    ),
+  ].sort();
+  const existingCategories = [
+    ...new Set(
+      teams
+        .filter(
+          (t) =>
+            t.sport === newTeamSport &&
+            (!newTeamLeague || t.league === newTeamLeague),
+        )
+        .map((t) => t.category)
+        .filter((c): c is string => Boolean(c)),
+    ),
+  ].sort();
+
+  const teamFieldSelectClass =
+    "w-full bg-transparent border border-purple-600 rounded text-purple-200 text-sm cursor-pointer focus:outline-none p-2 dark:bg-gray-900";
+  const teamFieldInputClass =
+    "w-full h-9 focus:outline-none text-sm text-left px-2 bg-transparent border border-purple-600 rounded text-purple-200";
 
   const allDrawersClosed =
     !isAddEntryDrawerOpen &&
@@ -337,36 +386,36 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
           </button>
         )}
         <Drawer
-            isOpen={isBalancesDrawerOpen}
-            onClose={() => setIsBalancesDrawerOpen(false)}
-            width="w-80"
-          >
-            <div className="flex-col space-y-4">
-              {users.map((u) => {
-                return (
-                  <div key={`${u.id}-profit`}>
-                    <div className="font-extrabold underline">{u.name}</div>
-                    <div>
-                      Total Net Profit:{" "}
-                      {formatProfit(calculateProfit(u.name, "", bets))}
-                      {users
-                        .filter((u2) => u2.id != u.id)
-                        .map((u2) => {
-                          return (
-                            <div key={`${u.id}-${u2.id}-profit`}>
-                              Profit vs {u2.name}:{" "}
-                              {formatProfit(
-                                calculateProfit(u.name, u2.name, bets),
-                              )}
-                            </div>
-                          );
-                        })}
-                    </div>
+          isOpen={isBalancesDrawerOpen}
+          onClose={() => setIsBalancesDrawerOpen(false)}
+          width="w-80"
+        >
+          <div className="flex-col space-y-4">
+            {users.map((u) => {
+              return (
+                <div key={`${u.id}-profit`}>
+                  <div className="font-extrabold underline">{u.name}</div>
+                  <div>
+                    Total Net Profit:{" "}
+                    {formatProfit(calculateProfit(u.name, "", bets))}
+                    {users
+                      .filter((u2) => u2.id != u.id)
+                      .map((u2) => {
+                        return (
+                          <div key={`${u.id}-${u2.id}-profit`}>
+                            Profit vs {u2.name}:{" "}
+                            {formatProfit(
+                              calculateProfit(u.name, u2.name, bets),
+                            )}
+                          </div>
+                        );
+                      })}
                   </div>
-                );
-              })}
-            </div>
-          </Drawer>
+                </div>
+              );
+            })}
+          </div>
+        </Drawer>
       </div>
 
       {/* Add Entry Drawer */}
@@ -422,6 +471,146 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
                 />
               </div>
 
+              {addEntryCollection === "Teams" && (
+                <div className="space-y-3">
+                  {/* Sport */}
+                  <div className="space-y-1">
+                    <div className="text-xs text-purple-400 font-semibold uppercase tracking-wide">
+                      Sport *
+                    </div>
+                    {!isNewSport ? (
+                      <select
+                        value={newTeamSport}
+                        onChange={(e) => {
+                          if (e.target.value === "__new__") {
+                            setIsNewSport(true);
+                            setNewTeamSport("");
+                            setNewTeamLeague("");
+                            setNewTeamCategory("");
+                          } else {
+                            setNewTeamSport(e.target.value);
+                            setNewTeamLeague("");
+                            setNewTeamCategory("");
+                            setIsNewLeague(false);
+                            setIsNewCategory(false);
+                          }
+                        }}
+                        className={teamFieldSelectClass}
+                      >
+                        <option value="" className="bg-gray-900">
+                          Select sport…
+                        </option>
+                        {existingSports.map((s) => (
+                          <option key={s} value={s} className="bg-gray-900">
+                            {s}
+                          </option>
+                        ))}
+                        <option value="__new__" className="bg-gray-900">
+                          + New sport…
+                        </option>
+                      </select>
+                    ) : (
+                      <input
+                        type="text"
+                        placeholder="New sport name…"
+                        value={newTeamSport}
+                        onChange={(e) => setNewTeamSport(e.target.value)}
+                        className={teamFieldInputClass}
+                        autoFocus
+                      />
+                    )}
+                  </div>
+
+                  {/* League — shown once sport is chosen */}
+                  {newTeamSport && (
+                    <div className="space-y-1">
+                      <div className="text-xs text-purple-400 font-semibold uppercase tracking-wide">
+                        League (optional)
+                      </div>
+                      {!isNewLeague ? (
+                        <select
+                          value={newTeamLeague}
+                          onChange={(e) => {
+                            if (e.target.value === "__new__") {
+                              setIsNewLeague(true);
+                              setNewTeamLeague("");
+                            } else {
+                              setNewTeamLeague(e.target.value);
+                              setNewTeamCategory("");
+                              setIsNewCategory(false);
+                            }
+                          }}
+                          className={teamFieldSelectClass}
+                        >
+                          <option value="" className="bg-gray-900">
+                            None
+                          </option>
+                          {existingLeagues.map((l) => (
+                            <option key={l} value={l} className="bg-gray-900">
+                              {l}
+                            </option>
+                          ))}
+                          <option value="__new__" className="bg-gray-900">
+                            + New league…
+                          </option>
+                        </select>
+                      ) : (
+                        <input
+                          type="text"
+                          placeholder="New league name…"
+                          value={newTeamLeague}
+                          onChange={(e) => setNewTeamLeague(e.target.value)}
+                          className={teamFieldInputClass}
+                        />
+                      )}
+                    </div>
+                  )}
+
+                  {/* Category — shown once sport is chosen */}
+                  {newTeamSport && (
+                    <div className="space-y-1">
+                      <div className="text-xs text-purple-400 font-semibold uppercase tracking-wide">
+                        Category (optional)
+                      </div>
+                      {!isNewCategory ? (
+                        <select
+                          value={newTeamCategory}
+                          onChange={(e) => {
+                            if (e.target.value === "__new__") {
+                              setIsNewCategory(true);
+                              setNewTeamCategory("");
+                            } else {
+                              setNewTeamCategory(e.target.value);
+                            }
+                          }}
+                          className={teamFieldSelectClass}
+                        >
+                          <option value="" className="bg-gray-900">
+                            None
+                          </option>
+                          {existingCategories.map((c) => (
+                            <option key={c} value={c} className="bg-gray-900">
+                              {c}
+                            </option>
+                          ))}
+                          <option value="__new__" className="bg-gray-900">
+                            + New category…
+                          </option>
+                        </select>
+                      ) : (
+                        <input
+                          type="text"
+                          placeholder="New category name…"
+                          value={newTeamCategory}
+                          onChange={(e) => setNewTeamCategory(e.target.value)}
+                          className={teamFieldInputClass}
+                        />
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+
               {addEntryCollection === "Lines" && (
                 <div className="w-full flex justify-between">
                   <button
@@ -459,7 +648,10 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
                   cursor-pointer focus:outline-none
                   disabled:opacity-40 disabled:cursor-not-allowed"
                 onClick={handleAddNewOption}
-                disabled={!newOptionName.trim()}
+                disabled={
+                  !newOptionName.trim() ||
+                  (addEntryCollection === "Teams" && !newTeamSport)
+                }
               >
                 Submit
               </button>

--- a/app/bet-log/bet-log.tsx
+++ b/app/bet-log/bet-log.tsx
@@ -97,7 +97,9 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
   // [0] = teamA (left), [1] = teamB (right)
   const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>(["", ""]);
   const [selectedMapId, setSelectedMapId] = useState<string>("mapMatch");
-  const [selectedLineId, setSelectedLineId] = useState<string>("");
+  const [selectedLineId, setSelectedLineId] = useState<string>(
+    _lines.find((l) => l.name === "Main Line")?.id ?? "",
+  );
 
   const handleUserAChange = (userId: string) => {
     if (userId && userId === selectedUserIds[1]) {

--- a/app/bet-log/bet-log.tsx
+++ b/app/bet-log/bet-log.tsx
@@ -369,10 +369,11 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
           </Drawer>
       </div>
 
-      {/* Add Entry Bottom Drawer */}
+      {/* Add Entry Drawer */}
       <BottomDrawer
         isOpen={isAddEntryDrawerOpen}
         onClose={() => setIsAddEntryDrawerOpen(false)}
+        direction="top"
       >
         <div className="space-y-4 text-purple-200">
           <div className="text-xl font-bold text-center">Add New Entry</div>

--- a/app/bet-log/bet-summary.tsx
+++ b/app/bet-log/bet-summary.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Handicap, OverUnder } from "../model/binary-option-and-number";
 import { LineType, type Line } from "../model/line";
 import type { Team } from "../model/team";
+import { getCategories, getLeagues, groupTeams } from "../model/team-grouping";
 import type { User } from "../model/user";
 import BottomDrawer from "../common-components/bottom-drawer";
 import FitText from "../common-components/fit-text";
@@ -61,7 +62,15 @@ export default function BetSummary({
   date,
 }: BetSummaryProps) {
   const [teamPickerSlot, setTeamPickerSlot] = useState<"A" | "B" | null>(null);
+  const [pickerScreen, setPickerScreen] = useState<
+    "sport" | "league" | "category" | "team"
+  >("sport");
+  const [pickerSport, setPickerSport] = useState<string | null>(null);
+  const [pickerLeague, setPickerLeague] = useState<string | null>(null);
+  const [pickerCat, setPickerCat] = useState<string | null>(null);
   const [teamSearch, setTeamSearch] = useState("");
+
+  const teamGroups = useMemo(() => groupTeams(teams), [teams]);
   const [linePickerOpen, setLinePickerOpen] = useState(false);
   const [lineSearch, setLineSearch] = useState("");
 
@@ -85,13 +94,96 @@ export default function BetSummary({
 
   const openTeamPicker = (slot: "A" | "B") => {
     setTeamPickerSlot(slot);
+    setPickerScreen("sport");
+    setPickerSport(null);
+    setPickerLeague(null);
+    setPickerCat(null);
+    setTeamSearch("");
     onTeamPickerOpenChange(true);
   };
 
   const closeTeamPicker = () => {
     setTeamPickerSlot(null);
+    setPickerScreen("sport");
+    setPickerSport(null);
+    setPickerLeague(null);
+    setPickerCat(null);
     setTeamSearch("");
     onTeamPickerOpenChange(false);
+  };
+
+  /** Advance picker after sport is chosen */
+  const selectSport = (sport: string) => {
+    setPickerSport(sport);
+    const group = teamGroups.find((g) => g.sport === sport);
+    if (!group) return;
+    const leagues = getLeagues(group);
+    if (leagues.length >= 2) {
+      setPickerScreen("league");
+    } else {
+      const league = group.leagues[0]?.league ?? "";
+      setPickerLeague(league);
+      const leagueGroup = group.leagues[0];
+      const cats = leagueGroup ? getCategories(leagueGroup) : [];
+      if (cats.length >= 2) {
+        setPickerScreen("category");
+      } else {
+        setPickerCat(leagueGroup?.entries[0]?.category ?? "");
+        setPickerScreen("team");
+      }
+    }
+  };
+
+  /** Advance picker after league is chosen */
+  const selectLeague = (league: string) => {
+    setPickerLeague(league);
+    const group = teamGroups.find((g) => g.sport === pickerSport);
+    const leagueGroup = group?.leagues.find((l) => l.league === league);
+    const cats = leagueGroup ? getCategories(leagueGroup) : [];
+    if (cats.length >= 2) {
+      setPickerScreen("category");
+    } else {
+      setPickerCat(leagueGroup?.entries[0]?.category ?? "");
+      setPickerScreen("team");
+    }
+  };
+
+  /** Go back one level in the picker */
+  const pickerGoBack = () => {
+    if (pickerScreen === "team") {
+      const group = teamGroups.find((g) => g.sport === pickerSport);
+      const leagueGroup = group?.leagues.find((l) => l.league === pickerLeague);
+      if (leagueGroup && getCategories(leagueGroup).length >= 2) {
+        setPickerCat(null);
+        setPickerScreen("category");
+      } else if (group && getLeagues(group).length >= 2) {
+        setPickerLeague(null);
+        setPickerCat(null);
+        setPickerScreen("league");
+      } else {
+        setPickerSport(null);
+        setPickerLeague(null);
+        setPickerCat(null);
+        setPickerScreen("sport");
+      }
+    } else if (pickerScreen === "category") {
+      const group = teamGroups.find((g) => g.sport === pickerSport);
+      if (group && getLeagues(group).length >= 2) {
+        setPickerLeague(null);
+        setPickerCat(null);
+        setPickerScreen("league");
+      } else {
+        setPickerSport(null);
+        setPickerLeague(null);
+        setPickerCat(null);
+        setPickerScreen("sport");
+      }
+    } else if (pickerScreen === "league") {
+      setPickerSport(null);
+      setPickerLeague(null);
+      setPickerCat(null);
+      setPickerScreen("sport");
+    }
   };
 
   const openLinePicker = () => {
@@ -126,9 +218,36 @@ export default function BetSummary({
   ));
 
   const activeTeam = teamPickerSlot === "A" ? teamA : teamB;
-  const filteredTeams = teams
-    .filter((t) => t.name.toLowerCase().includes(teamSearch.toLowerCase()))
-    .sort((a, b) => a.name.localeCompare(b.name));
+
+  /** Teams visible on the final "team" screen */
+  const pickerTeams = useMemo(() => {
+    if (pickerScreen !== "team") return [];
+    return teams
+      .filter(
+        (t) =>
+          (t.sport?.trim() || "Uncategorised") === pickerSport &&
+          (t.league?.trim() || "") === (pickerLeague ?? "") &&
+          (t.category?.trim() || "") === (pickerCat ?? "") &&
+          t.name.toLowerCase().includes(teamSearch.toLowerCase()),
+      )
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [teams, pickerScreen, pickerSport, pickerLeague, pickerCat, teamSearch]);
+
+  const pickerTitle =
+    pickerScreen === "league"
+      ? "Select League"
+      : pickerScreen === "category"
+      ? "Select Category"
+      : `Select Team ${teamPickerSlot === "A" ? "1" : "2"}`;
+
+  const pickerSubtitle =
+    pickerScreen === "league"
+      ? pickerSport
+      : pickerScreen === "category"
+      ? [pickerSport, pickerLeague].filter(Boolean).join(" › ")
+      : pickerScreen === "team"
+      ? [pickerSport, pickerLeague, pickerCat].filter(Boolean).join(" › ")
+      : null;
 
   const selectedLine = lines.find((l) => l.id === selectedLineId) ?? null;
   const selectedMap = maps.find((m) => m.id === selectedMapId) ?? null;
@@ -262,43 +381,139 @@ export default function BetSummary({
       </div>
 
       {/* Team picker drawer */}
-      <BottomDrawer isOpen={teamPickerSlot !== null} onClose={closeTeamPicker} direction="top">
+      <BottomDrawer
+        isOpen={teamPickerSlot !== null}
+        onClose={closeTeamPicker}
+        direction="top"
+      >
         <div className="space-y-3 text-purple-200">
-          <div className="text-xl font-bold text-center">
-            Select Team {teamPickerSlot === "A" ? "1" : "2"}
-          </div>
-
-          <input
-            type="text"
-            placeholder="Search teams..."
-            value={teamSearch}
-            onChange={(e) => setTeamSearch(e.target.value)}
-            className="w-full h-10 rounded-lg px-3 border-1 bg-transparent
-              border-purple-500 dark:border-purple-700
-              text-purple-200 focus:outline-none"
-            autoFocus
-          />
-
-          <div className="flex flex-wrap gap-2 max-h-56 overflow-y-auto pb-1">
-            {filteredTeams.map((t) => (
+          {/* Header: back button + title */}
+          <div className="flex items-center gap-2">
+            {pickerScreen !== "sport" && (
               <button
-                key={t.id}
-                className={pillClass(t.id === activeTeam?.id)}
-                onClick={() => {
-                  if (teamPickerSlot === "A") onTeamAChange(t.id);
-                  else onTeamBChange(t.id);
-                  closeTeamPicker();
-                }}
+                onClick={pickerGoBack}
+                className="text-purple-400 hover:text-purple-200 active:text-purple-100 p-1 cursor-pointer"
+                aria-label="Go back"
               >
-                {t.name}
+                ←
               </button>
-            ))}
+            )}
+            <div className="flex-1 text-center">
+              <div className="text-xl font-bold">{pickerTitle}</div>
+              {pickerSubtitle && (
+                <div className="text-sm text-purple-400">{pickerSubtitle}</div>
+              )}
+            </div>
+            {/* Spacer to balance the back button */}
+            {pickerScreen !== "sport" && <div className="w-7" />}
           </div>
+
+          {/* Sport screen */}
+          {pickerScreen === "sport" && (
+            <div className="space-y-2 max-h-64 overflow-y-auto pb-1">
+              {teamGroups.map((g) => (
+                <button
+                  key={g.sport}
+                  onClick={() => selectSport(g.sport)}
+                  className="w-full py-3 px-4 rounded-lg text-left font-semibold border-1
+                    border-purple-500 dark:border-purple-700
+                    bg-gray-400 dark:bg-purple-700/50
+                    hover:bg-purple-200 dark:hover:bg-purple-600
+                    active:bg-purple-300 dark:active:bg-purple-500
+                    cursor-pointer"
+                >
+                  {g.sport}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* League screen */}
+          {pickerScreen === "league" &&
+            (() => {
+              const group = teamGroups.find((g) => g.sport === pickerSport);
+              return (
+                <div className="flex flex-wrap gap-2 max-h-56 overflow-y-auto pb-1">
+                  {group?.leagues.map((lg) => (
+                    <button
+                      key={lg.league}
+                      className={pillClass(lg.league === pickerLeague)}
+                      onClick={() => selectLeague(lg.league)}
+                    >
+                      {lg.league || "(none)"}
+                    </button>
+                  ))}
+                </div>
+              );
+            })()}
+
+          {/* Category screen */}
+          {pickerScreen === "category" &&
+            (() => {
+              const group = teamGroups.find((g) => g.sport === pickerSport);
+              const leagueGroup = group?.leagues.find(
+                (l) => l.league === pickerLeague,
+              );
+              return (
+                <div className="flex flex-wrap gap-2 max-h-56 overflow-y-auto pb-1">
+                  {leagueGroup?.entries.map((entry) => (
+                    <button
+                      key={entry.category}
+                      className={pillClass(entry.category === pickerCat)}
+                      onClick={() => {
+                        setPickerCat(entry.category);
+                        setPickerScreen("team");
+                      }}
+                    >
+                      {entry.category || "(none)"}
+                    </button>
+                  ))}
+                </div>
+              );
+            })()}
+
+          {/* Team screen */}
+          {pickerScreen === "team" && (
+            <>
+              <input
+                type="text"
+                placeholder="Search teams..."
+                value={teamSearch}
+                onChange={(e) => setTeamSearch(e.target.value)}
+                className="w-full h-10 rounded-lg px-3 border-1 bg-transparent
+                  border-purple-500 dark:border-purple-700
+                  text-purple-200 focus:outline-none"
+                autoFocus
+              />
+              <div className="flex flex-wrap gap-2 max-h-56 overflow-y-auto pb-1">
+                {pickerTeams.map((t) => (
+                  <button
+                    key={t.id}
+                    className={pillClass(t.id === activeTeam?.id)}
+                    onClick={() => {
+                      if (teamPickerSlot === "A") onTeamAChange(t.id);
+                      else onTeamBChange(t.id);
+                      closeTeamPicker();
+                    }}
+                  >
+                    {t.name}
+                  </button>
+                ))}
+                {pickerTeams.length === 0 && (
+                  <div className="text-purple-500 text-sm">No teams found.</div>
+                )}
+              </div>
+            </>
+          )}
         </div>
       </BottomDrawer>
 
       {/* Line picker drawer */}
-      <BottomDrawer isOpen={linePickerOpen} onClose={closeLinePicker} direction="top">
+      <BottomDrawer
+        isOpen={linePickerOpen}
+        onClose={closeLinePicker}
+        direction="top"
+      >
         <div className="space-y-3 text-purple-200">
           <div className="text-xl font-bold text-center">Select Line</div>
 

--- a/app/bet-log/bet-summary.tsx
+++ b/app/bet-log/bet-summary.tsx
@@ -262,7 +262,7 @@ export default function BetSummary({
       </div>
 
       {/* Team picker drawer */}
-      <BottomDrawer isOpen={teamPickerSlot !== null} onClose={closeTeamPicker}>
+      <BottomDrawer isOpen={teamPickerSlot !== null} onClose={closeTeamPicker} direction="top">
         <div className="space-y-3 text-purple-200">
           <div className="text-xl font-bold text-center">
             Select Team {teamPickerSlot === "A" ? "1" : "2"}
@@ -298,7 +298,7 @@ export default function BetSummary({
       </BottomDrawer>
 
       {/* Line picker drawer */}
-      <BottomDrawer isOpen={linePickerOpen} onClose={closeLinePicker}>
+      <BottomDrawer isOpen={linePickerOpen} onClose={closeLinePicker} direction="top">
         <div className="space-y-3 text-purple-200">
           <div className="text-xl font-bold text-center">Select Line</div>
 

--- a/app/common-components/bottom-drawer.tsx
+++ b/app/common-components/bottom-drawer.tsx
@@ -5,12 +5,14 @@ interface BottomDrawerProps {
   isOpen: boolean;
   onClose: () => void;
   children: ReactNode;
+  direction?: "top" | "bottom";
 }
 
 const BottomDrawer: React.FC<BottomDrawerProps> = ({
   isOpen,
   onClose,
   children,
+  direction = "bottom",
 }) => {
   useEffect(() => {
     document.body.style.overflow = isOpen ? "hidden" : "auto";
@@ -31,8 +33,10 @@ const BottomDrawer: React.FC<BottomDrawerProps> = ({
         aria-hidden="true"
       />
       <div
-        className={`fixed bottom-0 left-0 right-0 max-w-lg mx-auto bg-white dark:bg-gray-950 border-t-2 border-x-2 border-purple-800 shadow-xl rounded-t-2xl z-50 transition-transform duration-300 ease-in-out ${
-          isOpen ? "translate-y-0" : "translate-y-full"
+        className={`fixed left-0 right-0 max-w-lg mx-auto bg-white dark:bg-gray-950 border-purple-800 shadow-xl z-50 transition-transform duration-300 ease-in-out ${
+          direction === "top"
+            ? `top-0 border-b-2 border-x-2 rounded-b-2xl ${isOpen ? "translate-y-0" : "-translate-y-full"}`
+            : `bottom-0 border-t-2 border-x-2 rounded-t-2xl ${isOpen ? "translate-y-0" : "translate-y-full"}`
         }`}
         role="dialog"
         aria-modal={isOpen}

--- a/app/common-components/drawer.tsx
+++ b/app/common-components/drawer.tsx
@@ -1,11 +1,13 @@
 import { useState, type ReactNode } from "react";
 
 type DrawerProps = {
-  trigger: ReactNode;
-  triggerSize: string;
+  trigger?: ReactNode;
+  triggerSize?: string;
   width: string;
   children: ReactNode;
   inline?: boolean;
+  isOpen?: boolean;
+  onClose?: () => void;
 };
 
 /**
@@ -20,21 +22,29 @@ const Drawer = ({
   width,
   children,
   inline,
+  isOpen: controlledIsOpen,
+  onClose: controlledOnClose,
 }: DrawerProps) => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [internalIsOpen, setInternalIsOpen] = useState(false);
 
-  const openDrawer = () => setIsOpen(true);
-  const closeDrawer = () => setIsOpen(false);
+  const isControlled = controlledIsOpen !== undefined;
+  const isOpen = isControlled ? controlledIsOpen : internalIsOpen;
+
+  const openDrawer = () => setInternalIsOpen(true);
+  const closeDrawer = () => {
+    if (isControlled) controlledOnClose?.();
+    else setInternalIsOpen(false);
+  };
 
   return (
     <>
-      {/* Floating Open Button */}
-      {!isOpen && (
+      {/* Floating Open Button — only in uncontrolled mode */}
+      {!isControlled && !isOpen && trigger && (
         <button
           onClick={openDrawer}
           className={`${
             inline ? "" : "fixed bottom-4 right-4 z-50 "
-          }${triggerSize} shadow-black shadow-lg cursor-pointer focus:outline-none`}
+          }${triggerSize ?? ""} shadow-black shadow-lg cursor-pointer focus:outline-none`}
           aria-label="Open Drawer"
         >
           {trigger}

--- a/app/model/team-grouping.ts
+++ b/app/model/team-grouping.ts
@@ -1,0 +1,65 @@
+import type { Team } from "./team";
+
+export type TeamEntry = { category: string; teams: Team[] };
+export type LeagueGroup = { league: string; entries: TeamEntry[] };
+export type SportGroup = { sport: string; leagues: LeagueGroup[] };
+
+export function groupTeams(teams: Team[]): SportGroup[] {
+  const sportMap = new Map<string, Map<string, Map<string, Team[]>>>();
+
+  for (const team of teams) {
+    const sport = team.sport?.trim() || "Uncategorised";
+    const league = team.league?.trim() || "";
+    const category = team.category?.trim() || "";
+
+    if (!sportMap.has(sport)) sportMap.set(sport, new Map());
+    const leagueMap = sportMap.get(sport)!;
+
+    if (!leagueMap.has(league)) leagueMap.set(league, new Map());
+    const catMap = leagueMap.get(league)!;
+
+    if (!catMap.has(category)) catMap.set(category, []);
+    catMap.get(category)!.push(team);
+  }
+
+  const result: SportGroup[] = [];
+
+  for (const [sport, leagueMap] of sportMap) {
+    const leagues: LeagueGroup[] = [];
+
+    for (const [league, catMap] of leagueMap) {
+      const entries: TeamEntry[] = [];
+
+      for (const [category, teamList] of catMap) {
+        entries.push({
+          category,
+          teams: [...teamList].sort((a, b) => a.name.localeCompare(b.name)),
+        });
+      }
+
+      entries.sort((a, b) => a.category.localeCompare(b.category));
+      leagues.push({ league, entries });
+    }
+
+    leagues.sort((a, b) => a.league.localeCompare(b.league));
+    result.push({ sport, leagues });
+  }
+
+  result.sort((a, b) => {
+    if (a.sport === "Uncategorised") return 1;
+    if (b.sport === "Uncategorised") return -1;
+    return a.sport.localeCompare(b.sport);
+  });
+
+  return result;
+}
+
+/** Returns distinct non-empty leagues for a given sport group */
+export function getLeagues(group: SportGroup): string[] {
+  return group.leagues.map((l) => l.league).filter(Boolean);
+}
+
+/** Returns distinct non-empty categories for a given league group */
+export function getCategories(leagueGroup: LeagueGroup): string[] {
+  return leagueGroup.entries.map((e) => e.category).filter(Boolean);
+}

--- a/app/model/team.ts
+++ b/app/model/team.ts
@@ -1,3 +1,7 @@
 import type { BaseFirebaseDocument } from "./base-firebase-document";
 
-export type Team = BaseFirebaseDocument & {};
+export type Team = BaseFirebaseDocument & {
+  sport?: string;
+  league?: string;
+  category?: string;
+};


### PR DESCRIPTION
## Summary

- **Unified FABs**: `$` (Show Balances) and `+` (Add Entry) now share identical styling; both hidden when any drawer is open, including the delete confirmation drawer
- **Top-sliding drawers**: all drawers (add-entry, team picker, line picker, delete confirm) now slide in from the top
- **Slide-to-confirm delete**: new `SlideToConfirm` component — user must drag a handle all the way right to confirm deletion, preventing accidental deletes
- **Scrollbar gutter**: `scrollbar-gutter: stable` eliminates the horizontal content shift that occurred when drawers opened/closed the scrollbar
- **Hierarchical team picker**: teams now have optional `sport`, `league`, and `category` fields; picker navigates Sport → League → Category → Team, skipping levels with only one option; existing bets unaffected as document IDs are preserved
- **Add-team form**: extended with cascading Sport / League / Category selects (each with a free-text "New…" escape hatch); sport is required
- **Default line**: page now defaults to "Main Line" on load

## Test plan

- [ ] Open team picker → sport list shown; tap LoL → league list; tap a league → category screen (Teams / Players); tap category → team pills with search
- [ ] Sports with a single league/category (Tennis, Basketball, Other) skip straight to teams
- [ ] Selecting a team already in the other slot swaps the two (existing behaviour preserved)
- [ ] Add new team via + FAB → sport required, league and category optional; new team appears in correct group immediately
- [ ] Delete a bet → confirmation drawer opens; FABs hidden; must slide all the way to confirm
- [ ] Open/close any drawer → no horizontal content shift on desktop
- [ ] Page load → Main Line pre-selected in the line picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)