### PR TITLE
fix: round bet outcome to cents to avoid floating point display artifacts

### DIFF
--- a/app/model/bet.ts
+++ b/app/model/bet.ts
@@ -105,7 +105,8 @@ export const getBetOutcome = (bet: Bet): BetOutcome | null => {
   if (bet.winner !== "userA" && bet.winner !== "userB") return null;
 
   if (bet.winner === "userA") {
-    const profit = bet.betAmount * (getBetMultiplier(bet.odds) - 1);
+    const profit =
+      Math.round(bet.betAmount * (getBetMultiplier(bet.odds) - 1) * 100) / 100;
     return { userA: profit, userB: -profit };
   }
   return { userA: -bet.betAmount, userB: bet.betAmount };


### PR DESCRIPTION
Multiplying betAmount by the derived multiplier for thirds-based odds
(e.g. 1.33/1.66) produces IEEE 754 residue like 19.999999996. Round the
userA profit to the nearest cent at the source so the stored/displayed
outcome matches the expected +/-$20.