### PR TITLE
Faster initial load + persisted balances aggregate

### DIFF
--- a/app/bet-log/bet-log.tsx
+++ b/app/bet-log/bet-log.tsx
@@ -1,22 +1,31 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { LineType, type Line } from "../model/line";
 import type { Team } from "../model/team";
 import type { User } from "../model/user";
 import {
   Bet,
-  getBetOutcome,
   type BetDto,
 } from "../model/bet";
+import {
+  type BalancesDoc,
+  type BalanceBet,
+  betPairContribution,
+  computeBalances,
+  profitVs,
+  totalProfit,
+} from "../model/balances";
 import BetHistory from "./bet-history";
 import {
   addDoc,
   collection,
   CollectionReference,
-  deleteDoc,
   doc,
   getDoc,
+  increment,
   onSnapshot,
-  updateDoc,
+  writeBatch,
+  type WriteBatch,
+  type DocumentReference,
 } from "firebase/firestore";
 import { db } from "../firebase";
 import Drawer from "../common-components/drawer";
@@ -42,11 +51,38 @@ const FIRESTORE_COLLECTION: Record<CollectionName, string> = {
   Lines: "lines",
 };
 
+/**
+ * Apply an old->new balance contribution change to the aggregate doc within a
+ * batch. Deltas are coalesced per pair key into a single increment so multiple
+ * writes to the same field in one batch don't clobber each other.
+ */
+const applyBalanceDeltas = (
+  batch: WriteBatch,
+  aggRef: DocumentReference<BalancesDoc>,
+  oldC: { key: string; amount: number } | null,
+  newC: { key: string; amount: number } | null,
+) => {
+  const deltas = new Map<string, number>();
+  if (oldC) deltas.set(oldC.key, (deltas.get(oldC.key) ?? 0) - oldC.amount);
+  if (newC)
+    deltas.set(
+      newC.key,
+      Math.round(((deltas.get(newC.key) ?? 0) + newC.amount) * 100) / 100,
+    );
+  const pairs: Record<string, ReturnType<typeof increment>> = {};
+  for (const [k, amt] of deltas) if (amt !== 0) pairs[k] = increment(amt);
+  if (Object.keys(pairs).length)
+    batch.set(aggRef, { pairs } as never, { merge: true });
+};
+
 export function BetLog({ _users, _teams, _lines }: BetLogProps) {
   const [users, setUsers] = useState<User[]>(_users);
   const [teams, setTeams] = useState<Team[]>(_teams);
   const [lines, setLines] = useState<Line[]>(_lines);
   const [bets, setBets] = useState<Bet[]>([]);
+  const [balances, setBalances] = useState<BalancesDoc>({ pairs: {} });
+
+  const aggRef = doc(db, "aggregates", "balances") as DocumentReference<BalancesDoc>;
 
   const [maps, setMaps] = useState<{ id: string; name: string }[]>([
     { id: "mapMatch", name: "Match" },
@@ -61,17 +97,35 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
     const unsubscribe = onSnapshot(
       collection(db, "bets") as CollectionReference<BetDto>,
       async (snapshot) => {
+        // Resolve userA/userB/teamA/teamB/line from already-loaded collections
+        // (the DocumentReference carries its .id) — no per-bet getDoc reads.
+        const usersById = new Map(users.map((u) => [u.id, u]));
+        const teamsById = new Map(teams.map((t) => [t.id, t]));
+        const linesById = new Map(lines.map((l) => [l.id, l]));
+
         const bets = await Promise.all(
-          snapshot.docs.map(async (doc) => {
-            const docData = doc.data();
+          snapshot.docs.map(async (snapDoc) => {
+            const d = snapDoc.data();
 
-            const userA = await getDoc(docData.userA);
-            const userB = await getDoc(docData.userB);
-            const teamA = await getDoc(docData.teamA);
-            const teamB = await getDoc(docData.teamB);
-            const line = await getDoc(docData.line);
+            // Edge case: a reference may point at an entity created on another
+            // device after this session loaded. Fetch only those misses.
+            const userA =
+              usersById.get(d.userA.id) ??
+              ({ ...(await getDoc(d.userA)).data()!, id: d.userA.id } as User);
+            const userB =
+              usersById.get(d.userB.id) ??
+              ({ ...(await getDoc(d.userB)).data()!, id: d.userB.id } as User);
+            const teamA =
+              teamsById.get(d.teamA.id) ??
+              ({ ...(await getDoc(d.teamA)).data()!, id: d.teamA.id } as Team);
+            const teamB =
+              teamsById.get(d.teamB.id) ??
+              ({ ...(await getDoc(d.teamB)).data()!, id: d.teamB.id } as Team);
+            const line =
+              linesById.get(d.line.id) ??
+              ({ ...(await getDoc(d.line)).data()!, id: d.line.id } as Line);
 
-            return new Bet(docData, doc.id, userA, userB, teamA, teamB, line);
+            return new Bet(d, snapDoc.id, userA, userB, teamA, teamB, line);
           }),
         );
 
@@ -92,7 +146,36 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
     );
 
     return () => unsubscribe();
+  }, [users, teams, lines]);
+
+  // Persisted balances aggregate — one tiny doc, updated at write-time.
+  useEffect(() => {
+    const unsubscribe = onSnapshot(aggRef, (snap) => {
+      setBalances(snap.data() ?? { pairs: {} });
+    });
+    return () => unsubscribe();
   }, []);
+
+  // DEV-only safety net: all bets are already in memory, so recompute and warn
+  // if the persisted aggregate ever drifts. Does not run in production.
+  const computedBalances = useMemo(() => computeBalances(bets as BalanceBet[]), [bets]);
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    if (!Object.keys(balances.pairs).length) return; // not backfilled yet
+    const keys = new Set([
+      ...Object.keys(balances.pairs),
+      ...Object.keys(computedBalances.pairs),
+    ]);
+    for (const k of keys) {
+      const a = balances.pairs[k] ?? 0;
+      const b = computedBalances.pairs[k] ?? 0;
+      if (Math.abs(a - b) > 0.01) {
+        console.warn(
+          `[balances drift] pair ${k}: aggregate=${a} computed=${b}`,
+        );
+      }
+    }
+  }, [computedBalances, balances]);
 
   const form = useBetFormState({
     maps,
@@ -117,7 +200,26 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
     ? bets.find((b) => b.id === editingBetId) ?? null
     : null;
   const handleBetEditSave = async (betId: string, data: Partial<BetDto>) => {
-    await updateDoc(doc(db, "bets", betId), data);
+    const oldBet = bets.find((b) => b.id === betId);
+    const betRef = doc(db, "bets", betId);
+    const batch = writeBatch(db);
+    batch.update(betRef, data);
+    if (oldBet) {
+      const newView: BalanceBet = {
+        userA: { id: data.userA?.id ?? oldBet.userA.id },
+        userB: { id: data.userB?.id ?? oldBet.userB.id },
+        betAmount: data.betAmount ?? oldBet.betAmount,
+        odds: data.odds ?? oldBet.odds,
+        winner: data.winner ?? oldBet.winner,
+      };
+      applyBalanceDeltas(
+        batch,
+        aggRef,
+        betPairContribution(oldBet as unknown as BalanceBet),
+        betPairContribution(newView),
+      );
+    }
+    await batch.commit();
   };
 
   const [isShowBetSettlementSpinner, setIsShowBetSettlementSpinner] =
@@ -129,11 +231,20 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
     setCurrentBetIdBeingSettled(betId);
 
     const betRef = doc(db, "bets", betId);
+    const oldBet = bets.find((b) => b.id === betId);
 
     try {
-      await updateDoc(betRef, {
-        winner: winner,
-      });
+      const batch = writeBatch(db);
+      batch.update(betRef, { winner });
+      if (oldBet) {
+        applyBalanceDeltas(
+          batch,
+          aggRef,
+          betPairContribution(oldBet as unknown as BalanceBet),
+          betPairContribution({ ...oldBet, winner } as unknown as BalanceBet),
+        );
+      }
+      await batch.commit();
 
       const updated = bets.map((bet) =>
         bet.id === betId ? { ...bet, winner: winner } : bet,
@@ -151,7 +262,18 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
     setIsShowBetSettlementSpinner(true);
     setCurrentBetIdBeingSettled(betId);
 
-    await deleteDoc(doc(db, "bets", betId));
+    const oldBet = bets.find((b) => b.id === betId);
+    const batch = writeBatch(db);
+    batch.delete(doc(db, "bets", betId));
+    if (oldBet) {
+      applyBalanceDeltas(
+        batch,
+        aggRef,
+        betPairContribution(oldBet as unknown as BalanceBet),
+        null,
+      );
+    }
+    await batch.commit();
   };
 
   // Add entry drawer state
@@ -278,6 +400,13 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
   const fabClass =
     "w-14 h-14 rounded-full bg-gray-900 border-1 border-purple-800 text-purple-200 text-3xl font-bold shadow-lg hover:bg-gray-800 hover:border-2 cursor-pointer focus:outline-none flex items-center justify-center";
 
+  // Read balances from the persisted aggregate; fall back to an in-memory
+  // computation until the one-time backfill has populated the aggregate doc.
+  const balanceSrc = Object.keys(balances.pairs).length
+    ? balances.pairs
+    : computedBalances.pairs;
+  const userIds = users.map((u) => u.id);
+
   return (
     <ToastProvider>
     <main className="flex-col p-3 space-y-4">
@@ -352,16 +481,14 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
                   <div className="font-extrabold underline">{u.name}</div>
                   <div>
                     Total Net Profit:{" "}
-                    {formatProfit(calculateProfit(u.name, "", bets))}
+                    {formatProfit(totalProfit(balanceSrc, u.id, userIds))}
                     {users
                       .filter((u2) => u2.id != u.id)
                       .map((u2) => {
                         return (
                           <div key={`${u.id}-${u2.id}-profit`}>
                             Profit vs {u2.name}:{" "}
-                            {formatProfit(
-                              calculateProfit(u.name, u2.name, bets),
-                            )}
+                            {formatProfit(profitVs(balanceSrc, u.id, u2.id))}
                           </div>
                         );
                       })}
@@ -703,32 +830,6 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
     </ToastProvider>
   );
 }
-
-/**
- * userA: the user whose balance is being calculated, the return value is net profit relative to them
- * userB: the other user who userA's profit is being calculated against, EMPTY STRING if all users
- */
-const calculateProfit = (userA: string, userB: string, bets: Bet[]) => {
-  return bets.reduce((total, bet) => {
-    const outcome = getBetOutcome(bet);
-    if (!outcome) return total;
-
-    if (
-      bet.userA.name === userA &&
-      (bet.userB.name === userB || userB === "")
-    ) {
-      return total + outcome.userA;
-    }
-    if (
-      bet.userB.name === userA &&
-      (bet.userA.name === userB || userB === "")
-    ) {
-      return total + outcome.userB;
-    }
-
-    return total;
-  }, 0.0);
-};
 
 const formatProfit = (profit: number) => {
   return `${profit < 0 ? "-" : "+"}$${profit < 0 ? -profit : profit}`;

--- a/app/model/balances.test.ts
+++ b/app/model/balances.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  type BalanceBet,
+  betPairContribution,
+  computeBalances,
+  pairKey,
+  profitVs,
+  totalProfit,
+} from "./balances";
+
+// Same fixture + expected numbers as the BEFORE characterization (which ran
+// against the old name-based calculateProfit). Asserting identical values via
+// the new id-based helpers proves behavioural equivalence across the refactor.
+
+const ALICE = { id: "u1", name: "Alice" };
+const BOB = { id: "u2", name: "Bob" };
+const CAROL = { id: "u3", name: "Carol" };
+const IDS = [ALICE.id, BOB.id, CAROL.id];
+
+const mk = (
+  userA: { id: string },
+  userB: { id: string },
+  betAmount: number,
+  odds: number,
+  winner: string,
+): BalanceBet => ({ userA, userB, betAmount, odds, winner });
+
+const FIXTURE: BalanceBet[] = [
+  mk(ALICE, BOB, 100, 2, "userA"), // Alice +100 vs Bob
+  mk(BOB, ALICE, 50, 2, "userB"), // Alice (as userB) +50 vs Bob
+  mk(ALICE, CAROL, 90, 1.33, "userA"), // Alice +30 vs Carol (thirds odds)
+  mk(CAROL, BOB, 200, 1.5, "userB"), // Bob (as userB) +200 vs Carol
+  mk(ALICE, BOB, 999, 3, ""), // unsettled -> ignored
+];
+
+const EXPECTED_PAIRWISE = {
+  AliceVsBob: 150,
+  AliceVsCarol: 30,
+  BobVsAlice: -150,
+  BobVsCarol: 200,
+  CarolVsAlice: -30,
+  CarolVsBob: -200,
+};
+
+const EXPECTED_TOTALS = { Alice: 180, Bob: 50, Carol: -230 };
+
+describe("balances (AFTER: id-based aggregate helpers)", () => {
+  const { pairs } = computeBalances(FIXTURE);
+
+  it("computes pairwise net profit", () => {
+    expect(profitVs(pairs, ALICE.id, BOB.id)).toBe(EXPECTED_PAIRWISE.AliceVsBob);
+    expect(profitVs(pairs, ALICE.id, CAROL.id)).toBe(EXPECTED_PAIRWISE.AliceVsCarol);
+    expect(profitVs(pairs, BOB.id, ALICE.id)).toBe(EXPECTED_PAIRWISE.BobVsAlice);
+    expect(profitVs(pairs, BOB.id, CAROL.id)).toBe(EXPECTED_PAIRWISE.BobVsCarol);
+    expect(profitVs(pairs, CAROL.id, ALICE.id)).toBe(EXPECTED_PAIRWISE.CarolVsAlice);
+    expect(profitVs(pairs, CAROL.id, BOB.id)).toBe(EXPECTED_PAIRWISE.CarolVsBob);
+  });
+
+  it("computes total net profit per user", () => {
+    expect(totalProfit(pairs, ALICE.id, IDS)).toBe(EXPECTED_TOTALS.Alice);
+    expect(totalProfit(pairs, BOB.id, IDS)).toBe(EXPECTED_TOTALS.Bob);
+    expect(totalProfit(pairs, CAROL.id, IDS)).toBe(EXPECTED_TOTALS.Carol);
+  });
+
+  it("is zero-sum across all users", () => {
+    const sum = IDS.reduce((s, id) => s + totalProfit(pairs, id, IDS), 0);
+    expect(sum).toBe(0);
+  });
+
+  it("ignores unsettled bets", () => {
+    const { pairs: p } = computeBalances([mk(ALICE, BOB, 999, 3, "")]);
+    expect(profitVs(p, ALICE.id, BOB.id)).toBe(0);
+  });
+
+  it("pairKey is order-independent", () => {
+    expect(pairKey(ALICE.id, BOB.id)).toBe(pairKey(BOB.id, ALICE.id));
+  });
+});
+
+// The aggregate write-path applies betPairContribution deltas incrementally.
+// This must always equal a from-scratch computeBalances of the surviving bets.
+describe("delta invariant: incremental aggregate == full recompute", () => {
+  const round2 = (n: number) => Math.round(n * 100) / 100;
+
+  // Apply old->new contribution to a running pairs map (mirrors applyBalanceDeltas).
+  const apply = (
+    pairs: Record<string, number>,
+    oldC: { key: string; amount: number } | null,
+    newC: { key: string; amount: number } | null,
+  ) => {
+    if (oldC) pairs[oldC.key] = round2((pairs[oldC.key] ?? 0) - oldC.amount);
+    if (newC) pairs[newC.key] = round2((pairs[newC.key] ?? 0) + newC.amount);
+  };
+
+  it("survives create -> settle -> edit -> unsettle -> delete", () => {
+    const running: Record<string, number> = {};
+    const live: BalanceBet[] = [];
+
+    const assertParity = () => {
+      const full = computeBalances(live).pairs;
+      const keys = new Set([...Object.keys(running), ...Object.keys(full)]);
+      for (const k of keys) {
+        expect(running[k] ?? 0).toBeCloseTo(full[k] ?? 0, 6);
+      }
+    };
+
+    // create (unsettled) -> no contribution
+    const bet1 = mk(ALICE, BOB, 100, 2, "");
+    live.push(bet1);
+    apply(running, null, betPairContribution(bet1));
+    assertParity();
+
+    // settle bet1 -> userA wins
+    const bet1Settled = { ...bet1, winner: "userA" };
+    apply(running, betPairContribution(bet1), betPairContribution(bet1Settled));
+    live[0] = bet1Settled;
+    assertParity();
+
+    // add + settle a second bet on a different pair
+    const bet2 = mk(CAROL, BOB, 200, 1.5, "userB");
+    live.push(bet2);
+    apply(running, null, betPairContribution(bet2));
+    assertParity();
+
+    // edit bet1: change amount/odds
+    const bet1Edited = { ...bet1Settled, betAmount: 90, odds: 1.33 };
+    apply(running, betPairContribution(bet1Settled), betPairContribution(bet1Edited));
+    live[0] = bet1Edited;
+    assertParity();
+
+    // unsettle bet1
+    const bet1Unsettled = { ...bet1Edited, winner: "" };
+    apply(running, betPairContribution(bet1Edited), betPairContribution(bet1Unsettled));
+    live[0] = bet1Unsettled;
+    assertParity();
+
+    // delete bet2
+    apply(running, betPairContribution(bet2), null);
+    live.splice(1, 1);
+    assertParity();
+  });
+});

--- a/app/model/balances.ts
+++ b/app/model/balances.ts
@@ -1,0 +1,69 @@
+import { getBetOutcome } from "./bet";
+
+/**
+ * Persisted balances aggregate. Keyed by stable user IDs (rename-safe) as
+ * canonical unordered pairs so each pair is stored once.
+ *
+ * pairs[key] = net profit of the LOWER id against the HIGHER id.
+ */
+export type BalancesDoc = { pairs: Record<string, number> };
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+
+/** Canonical, order-independent key for a pair of user ids. */
+export const pairKey = (a: string, b: string): string =>
+  a < b ? `${a}__${b}` : `${b}__${a}`;
+
+/** A bet-shaped value with just the fields balances care about. */
+export type BalanceBet = {
+  userA: { id: string };
+  userB: { id: string };
+  betAmount: number;
+  odds: number;
+  winner: string;
+};
+
+/**
+ * Net contribution of a single bet to its canonical pair, expressed as the
+ * lower id's profit against the higher id. Returns null for unsettled bets.
+ */
+export const betPairContribution = (
+  bet: BalanceBet,
+): { key: string; amount: number } | null => {
+  const outcome = getBetOutcome(bet as any);
+  if (!outcome) return null;
+  const a = bet.userA.id;
+  const b = bet.userB.id;
+  return { key: pairKey(a, b), amount: a < b ? outcome.userA : outcome.userB };
+};
+
+/** Build the full aggregate from a list of bets (single O(N) pass). */
+export const computeBalances = (bets: BalanceBet[]): BalancesDoc => {
+  const pairs: Record<string, number> = {};
+  for (const bet of bets) {
+    const c = betPairContribution(bet);
+    if (!c) continue;
+    pairs[c.key] = round2((pairs[c.key] ?? 0) + c.amount);
+  }
+  return { pairs };
+};
+
+/** Net profit of user `aId` against user `bId`, read from the aggregate. */
+export const profitVs = (
+  pairs: Record<string, number>,
+  aId: string,
+  bId: string,
+): number => {
+  const v = pairs[pairKey(aId, bId)] ?? 0;
+  return aId < bId ? v : -v;
+};
+
+/** Total net profit of user `aId` across every other user. */
+export const totalProfit = (
+  pairs: Record<string, number>,
+  aId: string,
+  allUserIds: string[],
+): number =>
+  allUserIds
+    .filter((id) => id !== aId)
+    .reduce((sum, bId) => round2(sum + profitVs(pairs, aId, bId)), 0);

--- a/app/model/bet.test.ts
+++ b/app/model/bet.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { getBetMultiplier, getBetOutcome, type Bet } from "./bet";
+
+// These pure functions are the core money math. They are unchanged by the
+// balances refactor, so this file must stay green BEFORE and AFTER.
+
+describe("getBetMultiplier", () => {
+  it("returns plain decimal odds unchanged", () => {
+    expect(getBetMultiplier(2)).toBe(2);
+    expect(getBetMultiplier(1.5)).toBe(1.5);
+    expect(getBetMultiplier(3.25)).toBe(3.25);
+  });
+
+  it("expands X.33 to exact thirds (integerPart*3 + 1)/3", () => {
+    // 1.33 -> (1*3 + 1)/3 = 4/3
+    expect(getBetMultiplier(1.33)).toBeCloseTo(4 / 3, 10);
+    // 2.33 -> (2*3 + 1)/3 = 7/3
+    expect(getBetMultiplier(2.33)).toBeCloseTo(7 / 3, 10);
+  });
+
+  it("expands X.66 to exact thirds (integerPart*3 + 2)/3", () => {
+    // 1.66 -> (1*3 + 2)/3 = 5/3
+    expect(getBetMultiplier(1.66)).toBeCloseTo(5 / 3, 10);
+    // 3.66 -> (3*3 + 2)/3 = 11/3
+    expect(getBetMultiplier(3.66)).toBeCloseTo(11 / 3, 10);
+  });
+});
+
+// Minimal structural bet — getBetOutcome only reads winner/betAmount/odds.
+const bet = (over: Partial<Bet>): Bet =>
+  ({ betAmount: 100, odds: 2, winner: "", ...over }) as Bet;
+
+describe("getBetOutcome", () => {
+  it("returns null when unsettled", () => {
+    expect(getBetOutcome(bet({ winner: "" }))).toBeNull();
+    expect(getBetOutcome(bet({ winner: "draw" }))).toBeNull();
+  });
+
+  it("userA win: profit = betAmount * (multiplier - 1), userB loses that", () => {
+    // odds 2, stake 100 -> profit 100
+    expect(getBetOutcome(bet({ winner: "userA", betAmount: 100, odds: 2 }))).toEqual({
+      userA: 100,
+      userB: -100,
+    });
+    // odds 1.5, stake 100 -> profit 50
+    expect(getBetOutcome(bet({ winner: "userA", betAmount: 100, odds: 1.5 }))).toEqual({
+      userA: 50,
+      userB: -50,
+    });
+  });
+
+  it("userA win with thirds odds rounds to cents", () => {
+    // 1.33 -> 4/3 multiplier; stake 90 -> 90*(4/3 - 1) = 30
+    expect(getBetOutcome(bet({ winner: "userA", betAmount: 90, odds: 1.33 }))).toEqual({
+      userA: 30,
+      userB: -30,
+    });
+  });
+
+  it("userB win: userA loses the stake, userB gains the stake", () => {
+    expect(getBetOutcome(bet({ winner: "userB", betAmount: 100, odds: 2 }))).toEqual({
+      userA: -100,
+      userB: 100,
+    });
+  });
+});

--- a/app/model/bet.ts
+++ b/app/model/bet.ts
@@ -1,7 +1,5 @@
 import type {
-  DocumentData,
   DocumentReference,
-  DocumentSnapshot,
   Timestamp,
 } from "firebase/firestore";
 import type { BaseFirebaseDocument } from "./base-firebase-document";
@@ -43,38 +41,18 @@ export class Bet {
   constructor(
     dto: BetDto,
     id: string,
-    userA: DocumentSnapshot<User, DocumentData>,
-    userB: DocumentSnapshot<User, DocumentData>,
-    teamA: DocumentSnapshot<Team, DocumentData>,
-    teamB: DocumentSnapshot<Team, DocumentData>,
-    line: DocumentSnapshot<Line, DocumentData>,
+    userA: User,
+    userB: User,
+    teamA: Team,
+    teamB: Team,
+    line: Line,
   ) {
     this.id = id;
-
-    this.userA = {
-      ...userA.data()!,
-      id: userA.id,
-    };
-
-    this.userB = {
-      ...userB.data()!,
-      id: userB.id,
-    };
-
-    this.teamA = {
-      ...teamA.data()!,
-      id: teamA.id,
-    };
-
-    this.teamB = {
-      ...teamB.data()!,
-      id: teamB.id,
-    };
-
-    this.line = {
-      ...line.data()!,
-      id: line.id,
-    };
+    this.userA = userA;
+    this.userB = userB;
+    this.teamA = teamA;
+    this.teamB = teamB;
+    this.line = line;
 
     this.map = dto.map;
     this.extras = dto.extras as Record<string, any>;


### PR DESCRIPTION
## Summary

Opening the app was slow and balances were recomputed from the full bet history on every drawer render. This PR addresses both, with a test-first guardrail proving the new balances match the old ones exactly.

### 1. Kill redundant reference reads (~5N → ~N)
The bets `onSnapshot` resolved `userA`/`userB`/`teamA`/`teamB`/`line` with **5 `getDoc()` calls per bet** on every snapshot — even though all users, teams, and lines are already loaded at route init. Now they resolve from in-memory maps via the `DocumentReference.id`, with a `getDoc` fallback only for the rare cross-device miss.

### 2. Move balance math from read-time to write-time
`calculateProfit` was `O(U² · N)` per render, unmemoized, and keyed on user **name** (broke on rename). Replaced with a persisted Firestore aggregate `aggregates/balances`, keyed by stable user **ids** as **canonical unordered pairs** (`n·(n−1)/2` entries — one signed value per pair; the reverse direction is its negation). Settle / edit / delete each apply an old→new delta via `writeBatch` + atomic `increment`. The drawer reads one tiny doc, with an in-memory fallback until the aggregate is backfilled.

### Safety nets
- **DEV-only oracle**: recomputes balances in memory and `console.warn`s on any drift from the aggregate.
- **Backfill**: a temporary `/migrate-balances` route populated the aggregate (idempotent, already run and verified), then removed.

## Tests
- `app/model/bet.test.ts` — characterizes the unchanged money math (`getBetMultiplier` thirds expansion, `getBetOutcome`).
- `app/model/balances.test.ts` — the **same fixture + expected numbers** were asserted against the old name-based `calculateProfit` *before* the refactor and the new id-based helpers *after*, proving behavioural equivalence; plus a **delta-invariant** test showing incremental updates always equal a from-scratch recompute.
- Full suite green (14 tests); `tsc` clean.

## Verification
- Backfill run on live data produced a consistent aggregate (DEV oracle silent → aggregate == recompute).
- Balances drawer renders identical values to before the refactor (zero-sum, pairwise mirror).

🤖 Generated with [Claude Code](https://claude.com/claude-code)