### PR TITLE
feat: force dark mode regardless of OS color scheme preference

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -2,6 +2,8 @@
 
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
   --font-sans: "JetBrains Mono", ui-sans-serif, system-ui, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
@@ -11,8 +13,5 @@ html,
 body {
   @apply bg-white dark:bg-gray-950;
   scrollbar-gutter: stable;
-
-  @media (prefers-color-scheme: dark) {
-    color-scheme: dark;
-  }
+  color-scheme: dark;
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -29,12 +29,11 @@ export const links: Route.LinksFunction = () => [
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" className="dark">
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="theme-color" content="#030712" media="(prefers-color-scheme: dark)" />
-        <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+        <meta name="theme-color" content="#030712" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
         <meta name="apple-mobile-web-app-title" content="Bet Log" />


### PR DESCRIPTION
## Summary
- The app previously only rendered its dark theme when the browser reported `prefers-color-scheme: dark`, so users (and headless browsers) in light mode got a white background with washed-out cards.
- Redefine the Tailwind `dark` variant as class-based (`@custom-variant dark`) and hardcode `class=dark` on `<html>`, so all 80 existing `dark:` utilities apply unconditionally — no component changes needed.
- Make `color-scheme: dark` unconditional so scrollbars and native form controls render dark, and collapse the two `theme-color` metas into the single dark value.

## Test plan
- [x] Loaded the app in a browser emulating `prefers-color-scheme: light` and confirmed it renders the dark theme (black background, no white tint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)