### PR TITLE
feat: match first-load skeletons to the simplified UI

### DIFF
--- a/app/bet-log/bet-log.tsx
+++ b/app/bet-log/bet-log.tsx
@@ -30,6 +30,12 @@ import {
 import { db } from "../firebase";
 import Drawer from "../common-components/drawer";
 import Spinner from "../common-components/spinner";
+import BetHistorySkeleton from "../common-components/bet-history-skeleton";
+import {
+  AppTitle,
+  FAB_BASE_CLASS,
+  FAB_CONTAINER_CLASS,
+} from "../common-components/app-chrome";
 import { useBetFormState } from "./use-bet-form-state";
 import BetFormFields from "./bet-form-fields";
 import BetEditDrawer from "./bet-edit-drawer";
@@ -397,8 +403,7 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
     !isCreateBetDrawerOpen &&
     editingBetId === null;
 
-  const fabClass =
-    "w-14 h-14 rounded-full bg-gray-900 border-1 border-purple-800 text-purple-200 text-3xl font-bold shadow-lg hover:bg-gray-800 hover:border-2 cursor-pointer focus:outline-none flex items-center justify-center";
+  const fabClass = `${FAB_BASE_CLASS} text-purple-200 text-3xl font-bold hover:bg-gray-800 hover:border-2 cursor-pointer focus:outline-none flex items-center justify-center`;
 
   // Read balances from the persisted aggregate; fall back to an in-memory
   // computation until the one-time backfill has populated the aggregate doc.
@@ -411,7 +416,7 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
     <ToastProvider>
     <main className="flex-col p-3 space-y-4">
       {/* Floating bottom-right button group */}
-      <div className="fixed bottom-4 right-4 flex items-end gap-2 z-50">
+      <div className={FAB_CONTAINER_CLASS}>
         {/* + FAB */}
         {allDrawersClosed && (
           <button
@@ -742,9 +747,7 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
         </div>
       </Drawer>
 
-      <div className="w-full h-max text-4xl font-semibold text-center text-purple-200">
-        gamba kappachungus deluxe
-      </div>
+      <AppTitle />
 
       {/* Create Bet Drawer */}
       <Drawer
@@ -801,9 +804,7 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
       </Drawer>
 
       <div className="w-full min-h-32 relative">
-        <div className={`mt-10 ${bets.length === 0 ? "block" : "hidden"}`}>
-          <Spinner isShowSpinner={bets.length === 0} />
-        </div>
+        {bets.length === 0 && <BetHistorySkeleton />}
 
         <BetHistory
           bets={bets}

--- a/app/common-components/app-chrome.tsx
+++ b/app/common-components/app-chrome.tsx
@@ -1,0 +1,17 @@
+// Shared app chrome used by both the real page (bet-log.tsx) and the
+// pre-hydration HydrateFallback (root.tsx). Must stay a lightweight leaf
+// module — root.tsx renders it before the route bundle loads.
+
+export const FAB_CONTAINER_CLASS =
+  "fixed bottom-4 right-4 flex items-end gap-2 z-50";
+
+export const FAB_BASE_CLASS =
+  "w-14 h-14 rounded-full shadow-lg border-1 bg-gray-900 border-purple-800";
+
+export function AppTitle() {
+  return (
+    <div className="w-full h-max text-4xl font-semibold text-center text-purple-200">
+      gamba kappachungus deluxe
+    </div>
+  );
+}

--- a/app/common-components/bet-history-skeleton.tsx
+++ b/app/common-components/bet-history-skeleton.tsx
@@ -1,0 +1,21 @@
+/**
+ * Pulsing placeholder for the bet history list, shaped like the real
+ * tile column so first paint doesn't shift layout when data arrives.
+ */
+export default function BetHistorySkeleton() {
+  return (
+    <div role="status" className="w-full h-max flex justify-center">
+      <div className="w-[22rem] max-w-full space-y-1 flex flex-col animate-pulse">
+        {Array.from({ length: 20 }, (_, i) => (
+          <div
+            key={i}
+            className="h-28 rounded-lg border-1
+            bg-gray-400 dark:bg-purple-950/10
+            border-purple-500/50 dark:border-purple-700/50"
+          />
+        ))}
+      </div>
+      <span className="sr-only">Loading...</span>
+    </div>
+  );
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -9,6 +9,12 @@ import {
 
 import type { Route } from "./+types/root";
 import "./app.css";
+import BetHistorySkeleton from "./common-components/bet-history-skeleton";
+import {
+  AppTitle,
+  FAB_BASE_CLASS,
+  FAB_CONTAINER_CLASS,
+} from "./common-components/app-chrome";
 
 export const links: Route.LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -56,21 +62,18 @@ export default function App() {
 
 export function HydrateFallback() {
   return (
-    <div role="status" className="w-full p-8 animate-pulse">
-      <div className="h-64 w-full bg-gray-200 rounded-xl dark:bg-gray-700 mb-2.5"></div>
-      <div className="h-8 max-w-sm bg-gray-200 rounded-xl dark:bg-gray-700 mb-2.5"></div>
-      <div className="h-16 w-full bg-gray-200 rounded-xl dark:bg-gray-700 mb-2.5"></div>
-      <div className="h-8 max-w-sm bg-gray-200 rounded-xl dark:bg-gray-700 mb-2.5"></div>
-      <div className="h-32 w-full bg-gray-200 rounded-xl dark:bg-gray-700 mb-2.5"></div>
-      <div className="h-8 max-w-sm bg-gray-200 rounded-xl dark:bg-gray-700 mb-2.5"></div>
-      <div className="h-16 w-full bg-gray-200 rounded-xl dark:bg-gray-700 mb-2.5"></div>
-      <div className="h-max w-full max-sm:grid-cols-1 max-md:grid md:flex gap-4 max-md:grid-cols-2 md:justify-between">
-        <div className="h-16 w-64 bg-gray-200 rounded-xl dark:bg-gray-700"></div>
-        <div className="h-16 w-64 bg-gray-200 rounded-xl dark:bg-gray-700"></div>
-        <div className="h-16 w-64 bg-gray-200 rounded-xl dark:bg-gray-700"></div>
+    <main className="flex-col p-3 space-y-4">
+      <AppTitle />
+
+      <BetHistorySkeleton />
+
+      {/* Floating bottom-right button group */}
+      <div className={FAB_CONTAINER_CLASS}>
+        {Array.from({ length: 3 }, (_, i) => (
+          <div key={i} className={FAB_BASE_CLASS} />
+        ))}
       </div>
-      <span className="sr-only">Loading...</span>
-    </div>
+    </main>
   );
 }
 


### PR DESCRIPTION
## Summary

The `HydrateFallback` skeleton was modeled on an old, denser UI — full-width gray panels, alternating bars, and a three-box footer — none of which matches today's centered tile-column layout. Since the route's `clientLoader` awaits three Firestore fetches before anything renders, that skeleton is the entire first paint and worth getting right.

- **New shared `BetHistorySkeleton`** (`app/common-components/bet-history-skeleton.tsx`): a centered column of 20 pulsing tile placeholders using the real tiles' colors (`dark:bg-purple-950/10`, faded purple borders) and approximate footprint, with `role="status"` + screen-reader text preserved
- **`HydrateFallback`** now mirrors the real page: the actual title text renders immediately (it's static), the tile skeleton sits below it, and three FAB placeholders occupy the bottom-right — hydration fills in content instead of swapping layouts
- **The post-hydration loading state** (bets still streaming from Firebase) reuses the same skeleton instead of a bare centered spinner, so both loading phases look identical
- **New `app-chrome` module** shares `AppTitle` and the FAB classes between `root.tsx` and `bet-log.tsx`, preventing the fallback from silently drifting when the real chrome is restyled. It is deliberately a leaf module because `HydrateFallback` renders before the route bundle loads

## Known follow-up

The in-app loading state keys off `bets.length === 0`, so a genuinely empty bet log would show the skeleton indefinitely — same behavior as the old spinner. A `hasLoaded` flag in the Firebase snapshot callback would fix it properly; kept out of this PR to stay cosmetic-only.

## Test plan

- [x] Typecheck and full vitest suite pass (including the route test asserting the title renders)
- [x] Pre-hydration skeleton verified visually with script execution disabled (SSR HTML)
- [x] Loaded page verified unchanged: identical title classes, three FABs present
