### PR TITLE
feat: track cash transfers between users alongside bet profit

### DIFF
--- a/app/bet-log/bet-log.tsx
+++ b/app/bet-log/bet-log.tsx
@@ -6,13 +6,21 @@ import {
   Bet,
   type BetDto,
 } from "../model/bet";
+import type { Transfer, TransferDto } from "../model/transfer";
 import {
   type BalancesDoc,
   type BalanceBet,
+  type BalanceTransfer,
   betPairContribution,
   computeBalances,
+  computeTransferBalances,
+  owedVs,
+  pairsDrifted,
   profitVs,
+  totalOwed,
   totalProfit,
+  transferPairContribution,
+  transferredVs,
 } from "../model/balances";
 import BetHistory from "./bet-history";
 import {
@@ -24,6 +32,7 @@ import {
   increment,
   onSnapshot,
   setDoc,
+  Timestamp,
   writeBatch,
   type WriteBatch,
   type DocumentReference,
@@ -90,6 +99,12 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
   const [balances, setBalances] = useState<BalancesDoc>({ pairs: {} });
   const [betsLoaded, setBetsLoaded] = useState(false);
   const [balancesLoaded, setBalancesLoaded] = useState(false);
+  const [transfers, setTransfers] = useState<Transfer[]>([]);
+  const [transferBalances, setTransferBalances] = useState<BalancesDoc>({
+    pairs: {},
+  });
+  const [transfersLoaded, setTransfersLoaded] = useState(false);
+  const [transferBalancesLoaded, setTransferBalancesLoaded] = useState(false);
 
   // Balance-aggregate writes use non-idempotent increment()s, so a duplicated
   // handler invocation (e.g. two confirm events for one gesture) would apply
@@ -98,6 +113,7 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
   const balanceWriteInFlightRef = useRef(false);
 
   const aggRef = doc(db, "aggregates", "balances") as DocumentReference<BalancesDoc>;
+  const transferAggRef = doc(db, "aggregates", "transfers") as DocumentReference<BalancesDoc>;
 
   const [maps, setMaps] = useState<{ id: string; name: string }[]>([
     { id: "mapMatch", name: "Match" },
@@ -173,41 +189,102 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
     return () => unsubscribe();
   }, []);
 
+  // Money transferred between users, tracked in parallel with bet profit.
+  useEffect(() => {
+    const unsubscribe = onSnapshot(
+      collection(db, "transfers") as CollectionReference<TransferDto>,
+      async (snapshot) => {
+        const usersById = new Map(users.map((u) => [u.id, u]));
+
+        const loaded = await Promise.all(
+          snapshot.docs.map(async (snapDoc) => {
+            const d = snapDoc.data();
+            const from =
+              usersById.get(d.from.id) ??
+              ({ ...(await getDoc(d.from)).data()!, id: d.from.id } as User);
+            const to =
+              usersById.get(d.to.id) ??
+              ({ ...(await getDoc(d.to)).data()!, id: d.to.id } as User);
+            return {
+              id: snapDoc.id,
+              from,
+              to,
+              amount: d.amount,
+              date: d.date,
+            } satisfies Transfer;
+          }),
+        );
+
+        setTransfers(
+          [...loaded].sort((a, b) => b.date.toMillis() - a.date.toMillis()),
+        );
+        setTransfersLoaded(true);
+      },
+    );
+
+    return () => unsubscribe();
+  }, [users]);
+
+  // Persisted transfers aggregate — same shape as the balances aggregate.
+  useEffect(() => {
+    const unsubscribe = onSnapshot(transferAggRef, (snap) => {
+      setTransferBalances(snap.data() ?? { pairs: {} });
+      setTransferBalancesLoaded(true);
+    });
+    return () => unsubscribe();
+  }, []);
+
   // Self-healing safety net: every bet is already in memory, so the persisted
   // aggregate can always be checked against a from-scratch recompute. If they
   // disagree (e.g. a past duplicated increment left drifted values), overwrite
   // the aggregate with the recomputed truth. Also acts as the initial
   // backfill when the aggregate doc doesn't exist yet.
   const computedBalances = useMemo(() => computeBalances(bets as BalanceBet[]), [bets]);
-  useEffect(() => {
-    if (!betsLoaded || !balancesLoaded) return;
-    const keys = new Set([
-      ...Object.keys(balances.pairs),
-      ...Object.keys(computedBalances.pairs),
-    ]);
-    let hasDrift = false;
-    for (const k of keys) {
-      if (Math.abs((balances.pairs[k] ?? 0) - (computedBalances.pairs[k] ?? 0)) > 0.005) {
-        hasDrift = true;
-        break;
-      }
-    }
-    if (!hasDrift) return;
-    // Debounce: the bets and balances listeners update in separate ticks, so a
-    // just-committed settlement looks like drift for a moment. Only repair
-    // drift that survives both listeners settling and no write in flight.
-    const timer = setTimeout(() => {
-      if (balanceWriteInFlightRef.current) return;
-      console.warn(
-        "[balances drift] persisted aggregate disagrees with recompute — repairing",
-        { persisted: balances.pairs, recomputed: computedBalances.pairs },
-      );
-      setDoc(aggRef, computedBalances).catch((error) =>
-        console.error("Error repairing balances aggregate:", error),
-      );
-    }, 2000);
-    return () => clearTimeout(timer);
-  }, [computedBalances, balances, betsLoaded, balancesLoaded]);
+  const computedTransferBalances = useMemo(
+    () => computeTransferBalances(transfers as BalanceTransfer[]),
+    [transfers],
+  );
+
+  // Debounce: the source and aggregate listeners update in separate ticks, so
+  // a just-committed write looks like drift for a moment. Only repair drift
+  // that survives both listeners settling and no write in flight.
+  const useAggregateRepair = (
+    label: string,
+    ready: boolean,
+    persisted: BalancesDoc,
+    recomputed: BalancesDoc,
+    ref: DocumentReference<BalancesDoc>,
+  ) =>
+    useEffect(() => {
+      if (!ready) return;
+      if (!pairsDrifted(persisted.pairs, recomputed.pairs)) return;
+      const timer = setTimeout(() => {
+        if (balanceWriteInFlightRef.current) return;
+        console.warn(
+          `[${label} drift] persisted aggregate disagrees with recompute — repairing`,
+          { persisted: persisted.pairs, recomputed: recomputed.pairs },
+        );
+        setDoc(ref, recomputed).catch((error) =>
+          console.error(`Error repairing ${label} aggregate:`, error),
+        );
+      }, 2000);
+      return () => clearTimeout(timer);
+    }, [ready, persisted, recomputed]);
+
+  useAggregateRepair(
+    "balances",
+    betsLoaded && balancesLoaded,
+    balances,
+    computedBalances,
+    aggRef,
+  );
+  useAggregateRepair(
+    "transfers",
+    transfersLoaded && transferBalancesLoaded,
+    transferBalances,
+    computedTransferBalances,
+    transferAggRef,
+  );
 
   const form = useBetFormState({
     maps,
@@ -324,6 +401,83 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
       await batch.commit();
     } finally {
       balanceWriteInFlightRef.current = false;
+    }
+  };
+
+  // Transfer entry form state
+  const [transferFromId, setTransferFromId] = useState<string>("");
+  const [transferToId, setTransferToId] = useState<string>("");
+  const [transferAmount, setTransferAmount] = useState<string>("");
+  const [transferDate, setTransferDate] = useState<string>(
+    () => new Date().toISOString().split("T")[0],
+  );
+  const [confirmingTransferDeleteId, setConfirmingTransferDeleteId] =
+    useState<string | null>(null);
+
+  const transferAmountNumber = Number(transferAmount);
+  const isTransferValid =
+    transferFromId !== "" &&
+    transferToId !== "" &&
+    transferFromId !== transferToId &&
+    Number.isFinite(transferAmountNumber) &&
+    transferAmountNumber > 0;
+
+  const handleTransferSubmit = async () => {
+    if (!isTransferValid) return;
+    if (balanceWriteInFlightRef.current) return;
+    balanceWriteInFlightRef.current = true;
+
+    try {
+      const amount = Math.round(transferAmountNumber * 100) / 100;
+      const batch = writeBatch(db);
+      const transferRef = doc(collection(db, "transfers"));
+      batch.set(transferRef, {
+        from: doc(db, "users", transferFromId),
+        to: doc(db, "users", transferToId),
+        amount,
+        date: Timestamp.fromDate(new Date(transferDate)),
+      });
+      applyBalanceDeltas(
+        batch,
+        transferAggRef,
+        null,
+        transferPairContribution({
+          from: { id: transferFromId },
+          to: { id: transferToId },
+          amount,
+        }),
+      );
+      await batch.commit();
+      setTransferAmount("");
+    } catch (error) {
+      console.error("Error recording transfer:", error);
+    } finally {
+      balanceWriteInFlightRef.current = false;
+    }
+  };
+
+  const handleTransferDeletion = async (transferId: string) => {
+    if (balanceWriteInFlightRef.current) return;
+    balanceWriteInFlightRef.current = true;
+
+    try {
+      const oldTransfer = transfers.find((t) => t.id === transferId);
+      const batch = writeBatch(db);
+      batch.delete(doc(db, "transfers", transferId));
+      if (oldTransfer) {
+        applyBalanceDeltas(
+          batch,
+          transferAggRef,
+          transferPairContribution(oldTransfer as unknown as BalanceTransfer),
+          null,
+        );
+      }
+      await batch.commit();
+    } catch (error) {
+      console.error("Error deleting transfer:", error);
+    } finally {
+      balanceWriteInFlightRef.current = false;
+      setConfirmingTransferDeleteId(null);
     }
   };
 
@@ -455,6 +609,9 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
   const balanceSrc = Object.keys(balances.pairs).length
     ? balances.pairs
     : computedBalances.pairs;
+  const transferSrc = Object.keys(transferBalances.pairs).length
+    ? transferBalances.pairs
+    : computedTransferBalances.pairs;
   const userIds = users.map((u) => u.id);
 
   return (
@@ -521,31 +678,197 @@ export function BetLog({ _users, _teams, _lines }: BetLogProps) {
         )}
         <Drawer
           isOpen={isBalancesDrawerOpen}
-          onClose={() => setIsBalancesDrawerOpen(false)}
+          onClose={() => {
+            setIsBalancesDrawerOpen(false);
+            setConfirmingTransferDeleteId(null);
+          }}
           direction="right"
+          size="w-96 max-w-[92vw]"
         >
-          <div className="flex-col space-y-4">
-            {users.map((u) => {
-              return (
-                <div key={`${u.id}-profit`}>
-                  <div className="font-extrabold underline">{u.name}</div>
-                  <div>
-                    Total Net Profit:{" "}
-                    {formatProfit(totalProfit(balanceSrc, u.id, userIds))}
+          <div className="flex flex-col space-y-5 max-h-[calc(100dvh-8rem)] overflow-y-auto overscroll-contain pr-1">
+            {/* Per-user balances: profit from bets, transfers, and what's left owing */}
+            <div className="space-y-4">
+              {users.map((u) => {
+                return (
+                  <div key={`${u.id}-profit`}>
+                    <div className="font-extrabold underline">{u.name}</div>
+                    <div>
+                      Total Net Profit:{" "}
+                      {formatProfit(totalProfit(balanceSrc, u.id, userIds))}
+                    </div>
+                    <div>
+                      Total Unsettled:{" "}
+                      {formatProfit(
+                        totalOwed(balanceSrc, transferSrc, u.id, userIds),
+                      )}
+                    </div>
                     {users
                       .filter((u2) => u2.id != u.id)
                       .map((u2) => {
+                        const profit = profitVs(balanceSrc, u.id, u2.id);
+                        const paid = transferredVs(transferSrc, u.id, u2.id);
+                        const owed = owedVs(
+                          balanceSrc,
+                          transferSrc,
+                          u.id,
+                          u2.id,
+                        );
                         return (
-                          <div key={`${u.id}-${u2.id}-profit`}>
-                            Profit vs {u2.name}:{" "}
-                            {formatProfit(profitVs(balanceSrc, u.id, u2.id))}
+                          <div
+                            key={`${u.id}-${u2.id}-profit`}
+                            className="mt-1 text-sm"
+                          >
+                            <div>
+                              Profit vs {u2.name}: {formatProfit(profit)}
+                            </div>
+                            <div className="text-purple-400">
+                              {paid === 0
+                                ? `no transfers with ${u2.name}`
+                                : paid > 0
+                                ? `paid ${u2.name} $${paid}`
+                                : `received $${-paid} from ${u2.name}`}
+                            </div>
+                            <div
+                              className={
+                                owed > 0
+                                  ? "text-purple-300 font-semibold"
+                                  : owed < 0
+                                  ? "text-red-400 font-semibold"
+                                  : "text-purple-500"
+                              }
+                            >
+                              {owed === 0
+                                ? `settled up with ${u2.name}`
+                                : owed > 0
+                                ? `${u2.name} owes $${owed}`
+                                : `owes ${u2.name} $${-owed}`}
+                            </div>
                           </div>
                         );
                       })}
                   </div>
+                );
+              })}
+            </div>
+
+            {/* Record a transfer between two users */}
+            <div className="space-y-2 border-t border-purple-800 pt-3">
+              <div className="font-extrabold">Record Transfer</div>
+              <div className="flex items-center gap-2">
+                <select
+                  value={transferFromId}
+                  onChange={(e) => setTransferFromId(e.target.value)}
+                  className={teamFieldSelectClass}
+                  aria-label="Transfer from"
+                >
+                  <option value="" className="bg-gray-900">
+                    from...
+                  </option>
+                  {users.map((u) => (
+                    <option key={u.id} value={u.id} className="bg-gray-900">
+                      {u.name}
+                    </option>
+                  ))}
+                </select>
+                <span aria-hidden="true">→</span>
+                <select
+                  value={transferToId}
+                  onChange={(e) => setTransferToId(e.target.value)}
+                  className={teamFieldSelectClass}
+                  aria-label="Transfer to"
+                >
+                  <option value="" className="bg-gray-900">
+                    to...
+                  </option>
+                  {users.map((u) => (
+                    <option key={u.id} value={u.id} className="bg-gray-900">
+                      {u.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex gap-2">
+                <input
+                  type="number"
+                  inputMode="decimal"
+                  min="0"
+                  step="0.01"
+                  placeholder="amount $"
+                  value={transferAmount}
+                  onChange={(e) => setTransferAmount(e.target.value)}
+                  className={teamFieldInputClass}
+                  aria-label="Transfer amount"
+                />
+                <input
+                  type="date"
+                  value={transferDate}
+                  onChange={(e) => setTransferDate(e.target.value)}
+                  className={teamFieldInputClass}
+                  aria-label="Transfer date"
+                />
+              </div>
+              <button
+                onClick={handleTransferSubmit}
+                disabled={!isTransferValid}
+                className="w-full h-10 rounded-lg border-1 font-semibold
+                  bg-gray-400 dark:bg-purple-950/10
+                  border-purple-500 dark:border-purple-700
+                  hover:bg-purple-200 dark:hover:bg-purple-600
+                  active:bg-purple-300 dark:active:bg-purple-500
+                  cursor-pointer focus:outline-none
+                  disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                save transfer
+              </button>
+            </div>
+
+            {/* Transfer history */}
+            <div className="space-y-1 border-t border-purple-800 pt-3">
+              <div className="font-extrabold">Transfer History</div>
+              {transfers.length === 0 && (
+                <div className="text-sm text-purple-500">no transfers yet</div>
+              )}
+              {transfers.map((t) => (
+                <div
+                  key={t.id}
+                  className="flex items-center justify-between gap-2 text-sm"
+                >
+                  <div>
+                    {t.date.toDate().toLocaleDateString()} — {t.from.name} paid{" "}
+                    {t.to.name} ${t.amount}
+                  </div>
+                  {confirmingTransferDeleteId === t.id ? (
+                    <button
+                      onClick={() => handleTransferDeletion(t.id)}
+                      className="text-red-400 font-semibold cursor-pointer shrink-0"
+                    >
+                      confirm?
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => setConfirmingTransferDeleteId(t.id)}
+                      aria-label="Delete transfer"
+                      className="cursor-pointer shrink-0 text-purple-400 hover:text-red-500/75"
+                    >
+                      <svg
+                        className="w-5 h-5"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          stroke="currentColor"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth="2"
+                          d="M5 7h14m-9 3v8m4-8v8M10 3h4a1 1 0 0 1 1 1v3H9V4a1 1 0 0 1 1-1ZM6 7h12v13a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V7Z"
+                        />
+                      </svg>
+                    </button>
+                  )}
                 </div>
-              );
-            })}
+              ))}
+            </div>
           </div>
         </Drawer>
       </div>

--- a/app/model/balances.test.ts
+++ b/app/model/balances.test.ts
@@ -1,11 +1,18 @@
 import { describe, it, expect } from "vitest";
 import {
   type BalanceBet,
+  type BalanceTransfer,
   betPairContribution,
   computeBalances,
+  computeTransferBalances,
+  owedVs,
   pairKey,
+  pairsDrifted,
   profitVs,
+  totalOwed,
   totalProfit,
+  transferPairContribution,
+  transferredVs,
 } from "./balances";
 
 // Same fixture + expected numbers as the BEFORE characterization (which ran
@@ -138,5 +145,93 @@ describe("delta invariant: incremental aggregate == full recompute", () => {
     apply(running, betPairContribution(bet2), null);
     live.splice(1, 1);
     assertParity();
+  });
+});
+
+// Transfers are tracked in parallel with profit: profit says who won what,
+// transfers say who has actually paid what, and owedVs nets the two.
+describe("transfers: pair aggregate and outstanding debt", () => {
+  const tf = (
+    from: { id: string },
+    to: { id: string },
+    amount: number,
+  ): BalanceTransfer => ({ from, to, amount });
+
+  it("stores the lower id's net payment to the higher id", () => {
+    // u1 pays u2: positive from the lower id's side.
+    expect(transferPairContribution(tf(ALICE, BOB, 40))).toEqual({
+      key: pairKey(ALICE.id, BOB.id),
+      amount: 40,
+    });
+    // u2 pays u1: negative from the lower id's side.
+    expect(transferPairContribution(tf(BOB, ALICE, 40))).toEqual({
+      key: pairKey(ALICE.id, BOB.id),
+      amount: -40,
+    });
+  });
+
+  it("rejects degenerate transfers", () => {
+    expect(transferPairContribution(tf(ALICE, ALICE, 40))).toBeNull();
+    expect(transferPairContribution(tf(ALICE, BOB, 0))).toBeNull();
+    expect(transferPairContribution(tf(ALICE, BOB, -5))).toBeNull();
+  });
+
+  it("nets opposing transfers within a pair", () => {
+    const { pairs } = computeTransferBalances([
+      tf(ALICE, BOB, 100),
+      tf(BOB, ALICE, 30),
+    ]);
+    expect(transferredVs(pairs, ALICE.id, BOB.id)).toBe(70);
+    expect(transferredVs(pairs, BOB.id, ALICE.id)).toBe(-70);
+  });
+
+  it("nets transfers against profit into outstanding debt", () => {
+    // Alice is +150 profit vs Bob (Bob owes Alice 150).
+    const { pairs: profitPairs } = computeBalances([
+      { userA: ALICE, userB: BOB, betAmount: 100, odds: 2, winner: "userA" },
+      { userA: BOB, userB: ALICE, betAmount: 50, odds: 2, winner: "userB" },
+    ]);
+    expect(profitVs(profitPairs, ALICE.id, BOB.id)).toBe(150);
+
+    // Bob pays Alice 40 -> still owes 110.
+    const { pairs: transferPairs } = computeTransferBalances([
+      tf(BOB, ALICE, 40),
+    ]);
+    expect(owedVs(profitPairs, transferPairs, ALICE.id, BOB.id)).toBe(110);
+    expect(owedVs(profitPairs, transferPairs, BOB.id, ALICE.id)).toBe(-110);
+
+    // Bob settles in full -> nothing outstanding, profit history untouched.
+    const settled = computeTransferBalances([tf(BOB, ALICE, 150)]).pairs;
+    expect(owedVs(profitPairs, settled, ALICE.id, BOB.id)).toBe(0);
+    expect(profitVs(profitPairs, ALICE.id, BOB.id)).toBe(150);
+
+    // Overpayment flips the direction of the debt.
+    const overpaid = computeTransferBalances([tf(BOB, ALICE, 200)]).pairs;
+    expect(owedVs(profitPairs, overpaid, ALICE.id, BOB.id)).toBe(-50);
+  });
+
+  it("totalOwed sums outstanding debt across users and stays zero-sum", () => {
+    const { pairs: profitPairs } = computeBalances(FIXTURE);
+    const { pairs: transferPairs } = computeTransferBalances([
+      tf(BOB, ALICE, 100), // Bob pays down part of the 150 he owes Alice
+      tf(CAROL, BOB, 200), // Carol settles with Bob in full
+    ]);
+
+    expect(totalOwed(profitPairs, transferPairs, ALICE.id, IDS)).toBe(80);
+    expect(totalOwed(profitPairs, transferPairs, BOB.id, IDS)).toBe(-50);
+    expect(totalOwed(profitPairs, transferPairs, CAROL.id, IDS)).toBe(-30);
+
+    const sum = IDS.reduce(
+      (s, id) => s + totalOwed(profitPairs, transferPairs, id, IDS),
+      0,
+    );
+    expect(sum).toBe(0);
+  });
+
+  it("pairsDrifted flags real drift and tolerates rounding noise", () => {
+    expect(pairsDrifted({ a: 10 }, { a: 10.001 })).toBe(false);
+    expect(pairsDrifted({ a: 10 }, { a: 10.02 })).toBe(true);
+    expect(pairsDrifted({}, { a: 5 })).toBe(true);
+    expect(pairsDrifted({ a: 0 }, {})).toBe(false);
   });
 });

--- a/app/model/balances.ts
+++ b/app/model/balances.ts
@@ -67,3 +67,97 @@ export const totalProfit = (
   allUserIds
     .filter((id) => id !== aId)
     .reduce((sum, bId) => round2(sum + profitVs(pairs, aId, bId)), 0);
+
+/** True when two pairs maps disagree beyond rounding noise. */
+export const pairsDrifted = (
+  a: Record<string, number>,
+  b: Record<string, number>,
+): boolean => {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const k of keys) {
+    if (Math.abs((a[k] ?? 0) - (b[k] ?? 0)) > 0.005) return true;
+  }
+  return false;
+};
+
+// ---------------------------------------------------------------------------
+// Transfers: cash settlements between users, tracked in parallel with bet
+// profit. Their aggregate doc has the same shape as the profit aggregate:
+// pairs[key] = net amount the LOWER id has PAID the HIGHER id.
+// ---------------------------------------------------------------------------
+
+/** A transfer-shaped value with just the fields balances care about. */
+export type BalanceTransfer = {
+  from: { id: string };
+  to: { id: string };
+  amount: number;
+};
+
+/**
+ * Net contribution of a single transfer to its canonical pair, expressed as
+ * the lower id's net payment to the higher id. Returns null for degenerate
+ * transfers (self-payments, non-positive amounts).
+ */
+export const transferPairContribution = (
+  t: BalanceTransfer,
+): { key: string; amount: number } | null => {
+  if (t.from.id === t.to.id || !(t.amount > 0)) return null;
+  return {
+    key: pairKey(t.from.id, t.to.id),
+    amount: t.from.id < t.to.id ? t.amount : -t.amount,
+  };
+};
+
+/** Build the full transfers aggregate from a list of transfers. */
+export const computeTransferBalances = (
+  transfers: BalanceTransfer[],
+): BalancesDoc => {
+  const pairs: Record<string, number> = {};
+  for (const t of transfers) {
+    const c = transferPairContribution(t);
+    if (!c) continue;
+    pairs[c.key] = round2((pairs[c.key] ?? 0) + c.amount);
+  }
+  return { pairs };
+};
+
+/**
+ * Net amount user `aId` has paid user `bId` (negative = net received).
+ * Same read as profitVs — both aggregates store the lower id's value.
+ */
+export const transferredVs = (
+  pairs: Record<string, number>,
+  aId: string,
+  bId: string,
+): number => profitVs(pairs, aId, bId);
+
+/**
+ * What user `bId` still owes user `aId` once transfers are netted against
+ * profit. Positive: `bId` owes `aId`; negative: `aId` owes `bId`. Paying
+ * someone increases your standing against them, so this is profit plus net
+ * paid: if Bob owes Alice 100 of profit and pays her 40, Alice's profit is
+ * still +100 but her received 40 (transferredVs = -40) leaves +60 owed.
+ */
+export const owedVs = (
+  profitPairs: Record<string, number>,
+  transferPairs: Record<string, number>,
+  aId: string,
+  bId: string,
+): number =>
+  round2(
+    profitVs(profitPairs, aId, bId) + transferredVs(transferPairs, aId, bId),
+  );
+
+/** Total still owed to user `aId` across every other user (negative = owes). */
+export const totalOwed = (
+  profitPairs: Record<string, number>,
+  transferPairs: Record<string, number>,
+  aId: string,
+  allUserIds: string[],
+): number =>
+  allUserIds
+    .filter((id) => id !== aId)
+    .reduce(
+      (sum, bId) => round2(sum + owedVs(profitPairs, transferPairs, aId, bId)),
+      0,
+    );

--- a/app/model/transfer.ts
+++ b/app/model/transfer.ts
@@ -1,0 +1,24 @@
+import type { DocumentReference, Timestamp } from "firebase/firestore";
+import type { BaseFirebaseDocument } from "./base-firebase-document";
+import type { User } from "./user";
+
+/**
+ * A cash settlement between two users, recorded when money actually changes
+ * hands. Transfers live alongside bets: bets accrue profit, transfers pay it
+ * down, and the difference is what's still owed.
+ */
+export type TransferDto = BaseFirebaseDocument & {
+  from: DocumentReference<User>;
+  to: DocumentReference<User>;
+  amount: number;
+  date: Timestamp;
+};
+
+/** A transfer with its user references resolved. */
+export type Transfer = {
+  id: string;
+  from: User;
+  to: User;
+  amount: number;
+  date: Timestamp;
+};


### PR DESCRIPTION
Adds a parallel ledger of money actually paid between users so the app answers "who owes who what", not just "who won what".

## Data model

- **New `transfers` collection** — one doc per payment: `{ from: <users ref>, to: <users ref>, amount: number, date: Timestamp }`. User references (rename-safe), matching how bets store users.
- **New `aggregates/transfers` doc** — identical shape to `aggregates/balances`: `pairs["<lowId>__<highId>"] = net amount the lower id has PAID the higher id`. Updated with coalesced `increment()`s in the same write batch as the transfer doc (reusing `applyBalanceDeltas` and the in-flight write guard), and self-healed/backfilled against a from-scratch recompute of the loaded transfer list — the drift-repair logic is generalized to serve both aggregates, so the doc creates and corrects itself with no manual backfill.
- **Outstanding debt derives from the two ledgers**: `owedVs = profitVs + transferredVs`. Paying down a debt moves what's owed while leaving profit history untouched; overpayment flips the direction. `totalOwed` sums per user and stays zero-sum.

## UI (balances drawer, widened)

- Each opponent row now shows profit, net transfers ("paid Bob $40" / "received $40 from Bob"), and a plain-language outstanding line ("Bob owes $110" / "settled up"), plus a per-user **Total Unsettled** next to Total Net Profit.
- **Record Transfer** form: from/to selects, amount, date (defaults to today); validated against self-payments and non-positive amounts.
- **Transfer History** list (newest first) with two-tap delete that reverses the pair increment in the same batch.

## Tests

Model helpers covered by unit tests: contribution orientation, degenerate-transfer rejection, netting within a pair, owed math incl. full settlement and overpayment, zero-sum totals, and the drift detector. `npm run typecheck`, `npm run build`, and all 21 tests pass (the `bet-log-route.test.jsx` file still can't run without Firebase env config — pre-existing).

## Note

If Firestore security rules enumerate collections, they need entries permitting the `transfers` collection and the `aggregates/transfers` doc — rules aren't in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5zBmc6WcU7GaFbSz2C5Fu

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5zBmc6WcU7GaFbSz2C5Fu)_